### PR TITLE
Feat/api helper

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,0 +1,10 @@
+const axios = jest.genMockFromModule('axios');
+
+axios.get = jest.fn((url) => {
+  if (url.includes('related')) {
+    return Promise.resolve([]);
+  }
+  return Promise.resolve({});
+});
+
+module.exports = axios;

--- a/client/src/lib/api.js
+++ b/client/src/lib/api.js
@@ -1,0 +1,11 @@
+const axios = require('axios');
+
+const getRelatedGames = id => (
+  axios.get(`/api/games/${id}/related`)
+);
+
+const getGameDetail = id => (
+  axios.get(`/api/games/${id}`)
+);
+
+export { getRelatedGames, getGameDetail };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "change-case": "^3.0.2",
+    "axios": "^0.18.0",
     "dotenv": "^5.0.0",
     "express": "^4.16.2",
     "knex": "^0.14.4",

--- a/spec/client/api.spec.js
+++ b/spec/client/api.spec.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { getRelatedGames, getGameDetail } from '../../client/src/lib/api';
+
+describe('client api library', () => {
+  describe('getRelatedGames', () => {
+    test('should make a request to /api/games/:id/related', () => {
+      getRelatedGames(5);
+      expect(axios.get).toBeCalledWith('/api/games/5/related');
+    });
+
+    test('should return promise that resolves to response from api', () => (getRelatedGames(5)
+      .then((response) => {
+        expect(response).toBeInstanceOf(Array);
+      })
+    ));
+  });
+
+  describe('getRelatedGames', () => {
+    test('should make a request to /api/games/:id', () => {
+      getGameDetail(5);
+      expect(axios.get).toBeCalledWith('/api/games/5');
+    });
+
+    test('should return promise that resolves to response from api', () => (getGameDetail(5)
+      .then((response) => {
+        expect(response).toBeInstanceOf(Object);
+      })
+    ));
+  });
+});


### PR DESCRIPTION
Creates helper functions for use on client side to get data from API. Unit tested with axios mocks, no integration testing yet.

Tickets
[Write API Helpers](https://trello.com/c/uuo1iz1j/15-xs-write-api-helper-library-w-axios)
[Test API Helpers](https://trello.com/c/MevzM0vc/16-s-test-api-helper-library)

And note that this caused an additional ticket to be created (not implemented here, though):

[Refactor API route names](https://trello.com/c/sWub8JOe/25-xs-refactor-routes-to-be-prefixed-with-api) - this is also updated in the service plan document.

Update: Route rename implemented in [#10](https://github.com/NotAsBadAsItSteams/more-like-this/pull/10).