### PR TITLE
(refactor) rename routes to be prefixed with /api

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,6 @@ const app = express();
 
 mountEnvironmentMiddleware(app);
 
-app.use('/games', gamesRouter);
+app.use('/api/games', gamesRouter);
 
 module.exports = app;

--- a/spec/server/app.spec.js
+++ b/spec/server/app.spec.js
@@ -2,15 +2,15 @@ const request = require('supertest');
 const app = require('../../server/app');
 
 describe('server', () => {
-  test('responds to /games/:id/related with 200 status', () => (
+  test('responds to /api/games/:id/related with 200 status', () => (
     request(app)
-      .get('/games/5/related')
+      .get('/api/games/5/related')
       .expect(200)
   ));
 
-  test('responds to /games/:id with 200 status', () => (
+  test('responds to /api/games/:id with 200 status', () => (
     request(app)
-      .get('/games/5')
+      .get('/api/games/5')
       .expect(200)
   ));
 


### PR DESCRIPTION
Tiny rename of routes. Related to [PR #8](https://github.com/NotAsBadAsItSteams/more-like-this/pull/8).

[Trello ticket](https://trello.com/c/sWub8JOe/25-xs-refactor-routes-to-be-prefixed-with-api)