### PR TITLE
(init) adds database seeds for all tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 
 ### Setup
 1. Ensure you have required dependencies.
-2. Create a postgres database with `createdb more_like_this` and ensure your postgres user has access to that database.
-3. Copy `sample.env`, rename it `.env`, and fill in needed values.
-4. Install project dependencies with `npm install`.
-5. Run `npm run migrate` to create tables.
-6. Run `npm start` to start server.
+2. Create a postgres database with `createdb more_like_this` and ensure your postgres user has access to that database
+3. Copy `sample.env`, rename it `.env`, and fill in needed values
+4. Install project dependencies with `npm install`
+5. Run `npm run migrate` to create tables
+6. Run `npm run seed` to seed tables with data
+7. Run `npm start` to start server

--- a/db/seeds/games.js
+++ b/db/seeds/games.js
@@ -1,0 +1,5 @@
+const games = require('../../data/games');
+
+exports.seed = knex => knex('games')
+  .del()
+  .then(() => knex('games').insert(games));

--- a/db/seeds/screenshots.js
+++ b/db/seeds/screenshots.js
@@ -1,0 +1,5 @@
+const screenshots = require('../../data/screenshots');
+
+exports.seed = knex => knex('screenshots')
+  .del()
+  .then(() => knex('screenshots').insert(screenshots));

--- a/db/seeds/tags.js
+++ b/db/seeds/tags.js
@@ -1,0 +1,10 @@
+const tags = require('../../data/tags');
+
+const jsonToTable = tag => ({
+  tag_id: tag.id,
+  name: tag.name,
+});
+
+exports.seed = knex => knex('tags')
+  .del()
+  .then(() => knex('tags').insert(tags.map(jsonToTable)));

--- a/db/seeds/tags_games.js
+++ b/db/seeds/tags_games.js
@@ -1,0 +1,5 @@
+const tagsGames = require('../../data/tags_games');
+
+exports.seed = knex => knex('tags_games')
+  .del()
+  .then(() => knex('tags_games').insert(tagsGames));

--- a/knexfile.js
+++ b/knexfile.js
@@ -11,4 +11,7 @@ module.exports = {
   migrations: {
     directory: path.join(__dirname, '/db/migrations'),
   },
+  seeds: {
+    directory: path.join(__dirname, '/db/seeds'),
+  },
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "migrate": "knex migrate:latest",
     "rollback": "knex migrate:rollback",
     "dev": "webpack -d --watch",
-    "generate:data": "node generators/index.js"
+    "generate:data": "node generators/index.js",
+    "seed": "knex seed:run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Seeding can now be done via `npm run seed`.

[Trello Ticket](https://trello.com/c/AQSiJJ5M/26-s-seed-database)